### PR TITLE
fix: --version flag generates error in production (#15)

### DIFF
--- a/lib/mix/tasks/tableau.new.ex
+++ b/lib/mix/tasks/tableau.new.ex
@@ -18,6 +18,8 @@ defmodule Mix.Tasks.Tableau.New do
   @moduledoc @help
   @shortdoc "Generate a new Tableau website"
 
+  @generator_version Mix.Project.config()[:version]
+
   use Mix.Task
 
   def run(argv) do
@@ -48,7 +50,7 @@ defmodule Mix.Tasks.Tableau.New do
     end
 
     if opts[:version] do
-      Mix.shell().info(Mix.Project.config()[:version])
+      Mix.shell().info(@generator_version)
 
       System.halt(0)
     end


### PR DESCRIPTION
The `--version` flag works in development mode when running in the context of a project, but not after using `mix archive.install hex tableau_new`.

Here is the error trace:

```
~> mix tableau.new --version
** (ArgumentError) invalid ANSI sequence specification: nil
    (elixir 1.16.1) lib/io/ansi.ex:261: IO.ANSI.format_sequence/1
    (elixir 1.16.1) lib/io/ansi.ex:316: IO.ANSI.do_format/5
    (mix 1.16.1) lib/mix/shell/io.ex:27: Mix.Shell.IO.info/1
    lib/mix/tasks/tableau.new.ex:51: Mix.Tasks.Tableau.New.run/1
    (mix 1.16.1) lib/mix/task.ex:478: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.16.1) lib/mix/cli.ex:96: Mix.CLI.run_task/2
    .asdf/installs/elixir/1.16.1-otp-26/bin/mix:2: (file)
```

I believe the problem arises because `Mix.Project.config()[:version]` is available in development but not production.

This PR sets the module attribute `@generator_version` at compile time.