### PR TITLE
fix(tailwindcss): remove `@source` directive from css file

### DIFF
--- a/priv/templates/tailwind/assets/css/site.css
+++ b/priv/templates/tailwind/assets/css/site.css
@@ -1,2 +1,1 @@
 @import "tailwindcss"
-@source './site.css';


### PR DESCRIPTION
The line `@source './site.css';` in `site.css` caused Tailwind to generate invalid CSS, breaking styling completely. 

(ubuntu 22.04 / tailwind 4.10.0 / tableau_new 1.5.0)

To generate the Tableau site: `mix tableau.new mysite --template heex --assets tailwind`

My styling test case, from lib/pages/home_page.ex: 
```
  def template(assigns) do
    ~H"""
    <p class="bg-amber-300">
      hello, world!
    </p>
    """
  end
```

After removing the line in `site.css`, the styling with Tailwind4 is working.

