### PR TITLE
fix(temple): wrap @app in string in root layout template.

### DIFF
--- a/priv/templates/temple/lib/layouts/root_layout.ex
+++ b/priv/templates/temple/lib/layouts/root_layout.ex
@@ -13,7 +13,7 @@ defmodule <%= @app_module %>.RootLayout do
           meta name: "viewport", content: "width=device-width, initial-scale=1.0"
 
           title do
-            [@page[:title], <%= @app %>]
+            [@page[:title], "<%= @app %>"]
             |> Enum.filter(& &1)
             |> Enum.intersperse("|")
             |> Enum.join(" ")
@@ -36,4 +36,3 @@ defmodule <%= @app_module %>.RootLayout do
     end
   end
 end
-


### PR DESCRIPTION
Does things the same way as in other generator root layouts: wraps content of `@app` in a string.